### PR TITLE
fix: update success response values to use fixed variables {}

### DIFF
--- a/n8n-test-workflow.json
+++ b/n8n-test-workflow.json
@@ -78,15 +78,15 @@
           "string": [
             {
               "name": "status",
-              "value": "success"
+              "value": "{}"
             },
             {
               "name": "response",
-              "value": "メッセージを受信しました: {{ $('Chat Message Webhook').item.json.body.message || 'メッセージなし' }}"
+              "value": "{}"
             },
             {
               "name": "processing_time",
-              "value": "{{ new Date().toISOString() }}"
+              "value": "{}"
             }
           ]
         }


### PR DESCRIPTION
Success Responseノードの値を変数{}で固定するように修正

修正内容:
- status: "{}"
- response: "{}"
- processing_time: "{}"

Generated with [Claude Code](https://claude.ai/code)